### PR TITLE
storagesystemsmodel: Introduce disk cache

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,6 +44,10 @@ jobs:
       run: |
         MAKEFLAGS=-j$(nproc) cmake --build ${BUILD_DIR}
 
+    - name: XDG Base Dirs
+      run: |
+        mkdir -p "$HOME/.qttest/cache"
+
     - name: Test
       env:
         CC: ${{matrix.config.CC}}

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -88,6 +88,7 @@ void printQObject(QObject *item)
 void listStorageSystems(QAlphaCloud::Connector *connector)
 {
     auto *storages = new StorageSystemsModel(connector);
+    storages->setCached(false);
 
     QObject::connect(storages, &StorageSystemsModel::statusChanged, [storages](QAlphaCloud::RequestStatus status) {
         if (status == QAlphaCloud::RequestStatus::Error) {
@@ -248,6 +249,7 @@ QString getPrimarySerial(Connector *connector)
 {
     cerr << "Fetching primary serial number..." << endl;
     StorageSystemsModel storages(connector, nullptr);
+    storages.setCached(false);
 
     QEventLoop loop;
     QObject::connect(&storages, &StorageSystemsModel::statusChanged, [&loop](QAlphaCloud::RequestStatus status) {

--- a/src/lib/storagesystemsmodel.h
+++ b/src/lib/storagesystemsmodel.h
@@ -36,6 +36,15 @@ class QALPHACLOUD_EXPORT StorageSystemsModel : public QAbstractListModel
     Q_PROPERTY(QAlphaCloud::Connector *connector READ connector WRITE setConnector NOTIFY connectorChanged REQUIRED)
 
     /**
+     * @brief Cache the data on disk
+     *
+     * Whether to cache the storage systems data on disk
+     * since it is unlikely to change often.
+     * Default is true.
+     */
+    Q_PROPERTY(bool cached READ cached WRITE setCached NOTIFY cachedChanged)
+
+    /**
      * @brief The number of items in the model
      */
     Q_PROPERTY(int count READ rowCount NOTIFY countChanged)
@@ -51,6 +60,9 @@ class QALPHACLOUD_EXPORT StorageSystemsModel : public QAbstractListModel
 
     /**
      * @brief The current request status
+     *
+     * The model may contain cached data before a request is sent
+     * and even if status is NoRequest.
      */
     Q_PROPERTY(QAlphaCloud::RequestStatus status READ status NOTIFY statusChanged)
 
@@ -105,6 +117,10 @@ public:
     Q_REQUIRED_RESULT QAlphaCloud::Connector *connector() const;
     void setConnector(QAlphaCloud::Connector *connector);
     Q_SIGNAL void connectorChanged(QAlphaCloud::Connector *connector);
+
+    Q_REQUIRED_RESULT bool cached() const;
+    void setCached(bool cached);
+    Q_SIGNAL void cachedChanged(bool cached);
 
     QAlphaCloud::RequestStatus status() const;
     Q_SIGNAL void statusChanged(QAlphaCloud::RequestStatus status);


### PR DESCRIPTION
The storage systems are unlikely to change often. By caching them we speed up fetching of initial data as we can start querying live data already. In the unlikely case they changed, this initial request will fail and a subsequent one issued with the updated serial number.

More importantly, it fixes Plasma System Monitor not enumerating the sensors properly when ksystemstats is autostarted on startup. It appears System Monitor does not expect sensor objects to be added dynamically after the sensor page has been created.