### PR TITLE
autotests: clang-format

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -31,4 +31,3 @@ jobs:
       uses: jidicula/clang-format-action@v4.11.0
       with:
         clang-format-version: '13'
-        check-path: 'src'

--- a/autotests/lastpowerdatatest.cpp
+++ b/autotests/lastpowerdatatest.cpp
@@ -8,9 +8,9 @@
 #include <QJsonObject>
 #include <QTest>
 
-#include <QAlphaCloud/QAlphaCloud>
 #include <QAlphaCloud/Connector>
 #include <QAlphaCloud/LastPowerData>
+#include <QAlphaCloud/QAlphaCloud>
 
 #include "testnetworkaccessmanager.h"
 
@@ -151,22 +151,18 @@ void LastPowerDataTest::testData()
 
 void LastPowerDataTest::testReloadEmpty()
 {
-
 }
 
 void LastPowerDataTest::testReloadError()
 {
-
 }
 
 void LastPowerDataTest::testReset()
 {
-
 }
 
 void LastPowerDataTest::testReloadInFlight()
 {
-
 }
 
 void LastPowerDataTest::testApiError()

--- a/autotests/onedateenergytest.cpp
+++ b/autotests/onedateenergytest.cpp
@@ -9,9 +9,9 @@
 #include <QJsonObject>
 #include <QTest>
 
-#include <QAlphaCloud/QAlphaCloud>
 #include <QAlphaCloud/Connector>
 #include <QAlphaCloud/OneDateEnergy>
+#include <QAlphaCloud/QAlphaCloud>
 
 #include "testnetworkaccessmanager.h"
 
@@ -129,8 +129,8 @@ void OneDateEnergyTest::testData()
     QCOMPARE(energy.photovoltaic(), 20100); // WattHours.
     QCOMPARE(energy.input(), 30);
     QCOMPARE(energy.output(), 14630);
-    //QCOMPARE(energy.charge(), 2800);
-    //QCOMPARE(energy.discharge(), 1000);
+    // QCOMPARE(energy.charge(), 2800);
+    // QCOMPARE(energy.discharge(), 1000);
     QCOMPARE(energy.gridCharge(), 10);
 
     // Also verify the raw JSON with the JSON from the file.
@@ -162,8 +162,8 @@ void OneDateEnergyTest::testData()
     QCOMPARE(energy.photovoltaic(), 200); // WattHours.
     QCOMPARE(energy.input(), 3500);
     QCOMPARE(energy.output(), 100);
-    //QCOMPARE(energy.charge(), 100);
-    //QCOMPARE(energy.discharge(), 1100);
+    // QCOMPARE(energy.charge(), 100);
+    // QCOMPARE(energy.discharge(), 1100);
     QCOMPARE(energy.gridCharge(), 2800);
 
     // Also verify the raw JSON with the JSON from the file.

--- a/autotests/onedaypowermodeltest.cpp
+++ b/autotests/onedaypowermodeltest.cpp
@@ -11,9 +11,9 @@
 #include <QSignalSpy>
 #include <QTest>
 
-#include <QAlphaCloud/QAlphaCloud>
 #include <QAlphaCloud/Connector>
 #include <QAlphaCloud/OneDayPowerModel>
+#include <QAlphaCloud/QAlphaCloud>
 
 #include "testnetworkaccessmanager.h"
 

--- a/autotests/storagesystemsmodeltest.cpp
+++ b/autotests/storagesystemsmodeltest.cpp
@@ -11,8 +11,8 @@
 #include <QStandardPaths>
 #include <QTest>
 
-#include <QAlphaCloud/QAlphaCloud>
 #include <QAlphaCloud/Connector>
+#include <QAlphaCloud/QAlphaCloud>
 #include <QAlphaCloud/StorageSystemsModel>
 
 #include "testnetworkaccessmanager.h"

--- a/autotests/testnetworkaccessmanager.cpp
+++ b/autotests/testnetworkaccessmanager.cpp
@@ -8,7 +8,6 @@
 TestNetworkAccessManager::TestNetworkAccessManager(QObject *parent)
     : QNetworkAccessManager(parent)
 {
-
 }
 
 TestNetworkAccessManager::~TestNetworkAccessManager() = default;

--- a/autotests/testnetworkaccessmanager.h
+++ b/autotests/testnetworkaccessmanager.h
@@ -7,7 +7,6 @@
 
 class TestNetworkAccessManager : public QNetworkAccessManager
 {
-
 public:
     TestNetworkAccessManager(QObject *parent = nullptr);
     ~TestNetworkAccessManager() override;
@@ -16,8 +15,7 @@ public:
     void setOverrideUrl(const QUrl &url);
 
 protected:
-    QNetworkReply *createRequest(Operation op, const QNetworkRequest &request,
-                                 QIODevice *outgoingData = nullptr) override;
+    QNetworkReply *createRequest(Operation op, const QNetworkRequest &request, QIODevice *outgoingData = nullptr) override;
 
 private:
     QUrl m_overrideUrl;

--- a/examples/cpp/livedatawidget/livedatawidget.cpp
+++ b/examples/cpp/livedatawidget/livedatawidget.cpp
@@ -35,13 +35,12 @@ LiveDataWidget::LiveDataWidget(QWidget *parent)
     config->setAppId(QStringLiteral("alpha..."));
     config->setAppSecret(QStringLiteral("..."));
     // or use this to load it from the QAlphaCloud config file.
-    //config->loadDefault();
+    // config->loadDefault();
 
     m_connector->setConfiguration(config);
 
     // Hook up the storage systems model signals.
-    connect(m_storageSystems, &StorageSystemsModel::statusChanged,
-            this, &LiveDataWidget::onStorageSystemsModelStatusChanged);
+    connect(m_storageSystems, &StorageSystemsModel::statusChanged, this, &LiveDataWidget::onStorageSystemsModelStatusChanged);
 
     // Set up live data. It needs a connector.
     m_liveData->setConnector(m_connector);


### PR DESCRIPTION
We only formatted the `src/` directory but `autotests/` and `examples/` are code, too.

If more reformatting happens, we should probably add a `.git-blame-ignore-revs` file.