### PR TITLE
Introduce errorText function

### DIFF
--- a/autotests/CMakeLists.txt
+++ b/autotests/CMakeLists.txt
@@ -1,6 +1,14 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # SPDX-FileCopyrightText: 2023 Kai Uwe Broulik <ghqalpha@broulik.de>
 
+ecm_add_test(namespacetest.cpp
+    TEST_NAME
+    qalphacloud-namespacetest
+    LINK_LIBRARIES
+    Qt${QT_MAJOR_VERSION}::Test
+    QAlphaCloud
+)
+
 ecm_add_test(configurationtest.cpp
     TEST_NAME
     qalphacloud-configurationtest

--- a/autotests/lastpowerdatatest.cpp
+++ b/autotests/lastpowerdatatest.cpp
@@ -197,6 +197,7 @@ void LastPowerDataTest::testGarbledJson()
 
     QTRY_COMPARE(data.status(), QAlphaCloud::RequestStatus::Error);
     QCOMPARE(data.error(), QAlphaCloud::ErrorCode::JsonParseError);
+    QVERIFY(!data.errorString().isEmpty());
     QVERIFY(!data.valid());
 }
 

--- a/autotests/namespacetest.cpp
+++ b/autotests/namespacetest.cpp
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Kai Uwe Broulik <ghqalpha@broulik.de>
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include <QCoreApplication>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QTest>
+
+#include <QAlphaCloud/QAlphaCloud>
+
+using namespace QAlphaCloud;
+
+class NamespaceTest : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void testErrorText_data();
+    void testErrorText();
+};
+
+void NamespaceTest::testErrorText_data()
+{
+    QTest::addColumn<ErrorCode>("code");
+    QTest::addColumn<QVariant>("details");
+    QTest::addColumn<QString>("expected");
+
+    QTest::newRow("API error with API msg") << ErrorCode::ParameterError << QVariant(QStringLiteral("API said no.")) << QStringLiteral("API said no.");
+
+    const QString jsonError = QStringLiteral("Unexpected , on line 2.");
+    QTest::newRow("JSON parse error") << ErrorCode::JsonParseError << QVariant(jsonError)
+                                      << QCoreApplication::translate("errorText", "Failed to parse JSON: %1").arg(jsonError);
+
+    QTest::newRow("Unexpected JSON error") << ErrorCode::UnexpectedJsonDataError << QVariant(QJsonDocument())
+                                           << QCoreApplication::translate("errorText", "Unexpected JSON content received.");
+
+    QTest::newRow("QNetworkReply error") << static_cast<ErrorCode>(QNetworkReply::TimeoutError) << QVariant()
+                                         << QCoreApplication::translate("errorText", "Operation timed out.");
+
+    QJsonArray array;
+    QJsonDocument arrayDoc(array);
+    QTest::newRow("Unexpected JSON Array error") << ErrorCode::UnexpectedJsonDataError << QVariant(arrayDoc)
+                                                 << QCoreApplication::translate("errorText", "Unexpected JSON Array received.");
+
+    QTest::newRow("Out of bounds") << static_cast<ErrorCode>(9999) << QVariant() << QString();
+
+    const QString outOfBounds = QStringLiteral("Out of bounds");
+    QTest::newRow("Out of bounds with msg") << static_cast<ErrorCode>(9999) << QVariant(outOfBounds) << outOfBounds;
+}
+
+void NamespaceTest::testErrorText()
+{
+    // We don't want to test translatable strings
+    // but at least some of the expected behavior.
+
+    QFETCH(ErrorCode, code);
+    QFETCH(QVariant, details);
+    QFETCH(QString, expected);
+
+    QCOMPARE(QAlphaCloud::errorText(code, details), expected);
+}
+
+QTEST_GUILESS_MAIN(NamespaceTest)
+#include "namespacetest.moc"

--- a/autotests/onedateenergytest.cpp
+++ b/autotests/onedateenergytest.cpp
@@ -206,6 +206,7 @@ void OneDateEnergyTest::testGarbledJson()
 
     QTRY_COMPARE(energy.status(), QAlphaCloud::RequestStatus::Error);
     QCOMPARE(energy.error(), QAlphaCloud::ErrorCode::JsonParseError);
+    QVERIFY(!energy.errorString().isEmpty());
     QVERIFY(!energy.valid());
 }
 

--- a/src/lib/apirequest.cpp
+++ b/src/lib/apirequest.cpp
@@ -166,9 +166,10 @@ bool ApiRequest::send()
 
             if (error.error != QJsonParseError::NoError) {
                 m_error = ErrorCode::JsonParseError;
-                m_errorString = error.errorString();
+                m_errorString = QAlphaCloud::errorText(m_error, error.errorString());
             } else if (!jsonDocument.isObject()) {
                 m_error = ErrorCode::UnexpectedJsonDataError;
+                m_errorString = QAlphaCloud::errorText(m_error, jsonDocument);
             } else {
                 const QJsonObject jsonObject = jsonDocument.object();
                 if (jsonObject.isEmpty()) {
@@ -177,8 +178,9 @@ bool ApiRequest::send()
                     code = jsonObject.value(QStringLiteral("code")).toInt();
                     if (code != 200) {
                         m_error = static_cast<QAlphaCloud::ErrorCode>(code);
+                        const QString msg = jsonObject.value(QStringLiteral("msg")).toString();
+                        m_errorString = QAlphaCloud::errorText(m_error, msg);
                     }
-                    m_errorString = jsonObject.value(QStringLiteral("msg")).toString();
 
                     m_data = jsonObject.value(QStringLiteral("data"));
                 }

--- a/src/lib/qalphacloud.cpp
+++ b/src/lib/qalphacloud.cpp
@@ -3,4 +3,119 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
-// Nothing to see here yet.
+#include "qalphacloud.h"
+
+#include <QCoreApplication>
+#include <QJsonDocument>
+#include <QMetaEnum>
+#include <QNetworkReply>
+
+namespace QAlphaCloud
+{
+
+QString errorText(ErrorCode code, const QVariant &details)
+{
+    const QString detailsString = details.toString();
+
+    switch (code) {
+    case ErrorCode::UnknownError:
+        return QCoreApplication::translate("errorText", "An unknown error occurred.");
+    case ErrorCode::NoError:
+        return QCoreApplication::translate("errorText", "The operation completed successfully.");
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wswitch"
+    case static_cast<ErrorCode>(QNetworkReply::TimeoutError):
+        return QCoreApplication::translate("errorText", "Operation timed out.");
+    case static_cast<ErrorCode>(QNetworkReply::OperationCanceledError):
+        return QCoreApplication::translate("errorText", "Operation was canceled.");
+#pragma GCC diagnostic pop
+
+    case ErrorCode::JsonParseError:
+        if (!detailsString.isEmpty()) {
+            return QCoreApplication::translate("errorText", "Failed to parse JSON: %1").arg(detailsString);
+        } else {
+            return QCoreApplication::translate("errorText", "Failed to parse JSON.");
+        }
+    case ErrorCode::UnexpectedJsonDataError: {
+        if (details.canConvert<QJsonDocument>()) {
+            const auto jsonDocument = details.toJsonDocument();
+            if (jsonDocument.isArray()) {
+                return QCoreApplication::translate("errorText", "Unexpected JSON Array received.");
+            }
+        }
+        return QCoreApplication::translate("errorText", "Unexpected JSON content received.");
+    }
+
+    case ErrorCode::ParameterError:
+        if (detailsString.isEmpty()) {
+            return QCoreApplication::translate("errorText", "Unexpected JSON content received.");
+        }
+        break;
+    case ErrorCode::SnNotBoundToUser:
+        if (detailsString.isEmpty()) {
+            return QCoreApplication::translate("errorText", "The provided serial number is not associated with this user.");
+        }
+        break;
+    case ErrorCode::CheckCodeError:
+        if (detailsString.isEmpty()) {
+            return QCoreApplication::translate("errorText", "Check code error.");
+        }
+        break;
+    case ErrorCode::AppIdNotBoundToSn:
+        if (detailsString.isEmpty()) {
+            return QCoreApplication::translate("errorText", "The provided application ID is not associated with this serial number.");
+        }
+        break;
+    case ErrorCode::TimestampError:
+        if (detailsString.isEmpty()) {
+            return QCoreApplication::translate("errorText", "The provided time stamp is either invalid, or too far in the past.");
+        }
+        break;
+    case ErrorCode::SignVerificationError:
+        if (detailsString.isEmpty()) {
+            return QCoreApplication::translate("errorText", "API secret verification error.");
+        }
+        break;
+    case ErrorCode::SetFailed:
+        if (detailsString.isEmpty()) {
+            return QCoreApplication::translate("errorText", "Failed to set requested configuration.");
+        }
+        break;
+    case ErrorCode::SignEmpty:
+        if (detailsString.isEmpty()) {
+            return QCoreApplication::translate("errorText", "API secret was not provided.");
+        }
+        break;
+    case ErrorCode::WhitelistVerificationFailed:
+        if (detailsString.isEmpty()) {
+            return QCoreApplication::translate("errorText", "Whitelist verification failed.");
+        }
+        break;
+    case ErrorCode::TimestampEmpty:
+        if (detailsString.isEmpty()) {
+            return QCoreApplication::translate("errorText", "Request time stamp was not provided.");
+        }
+        break;
+    case ErrorCode::AppIdEmpty:
+        if (detailsString.isEmpty()) {
+            return QCoreApplication::translate("errorText", "Application ID was not provided.");
+        }
+        break;
+
+    case ErrorCode::VerificationCode:
+        if (detailsString.isEmpty()) {
+            return QCoreApplication::translate("errorText", "Verification code error.");
+        }
+        break;
+    }
+
+    if (!detailsString.isEmpty()) {
+        return detailsString;
+    }
+
+    QMetaEnum metaEnum = QMetaEnum::fromType<ErrorCode>();
+    return QString::fromUtf8(metaEnum.valueToKey(static_cast<int>(code)));
+}
+
+} // namespace QAlphaCloud

--- a/src/lib/qalphacloud.h
+++ b/src/lib/qalphacloud.h
@@ -72,6 +72,15 @@ enum class ErrorCode {
 Q_ENUM_NS(ErrorCode)
 
 /**
+ * @brief Human-readable error text
+ * @param code The error code
+ * @param details Details about the error, for example a QString with the JSON parser error message,
+ * or a QJsonValue whose type is printed when a different one was expected, etc.
+ * @return A human-readable error description
+ */
+QALPHACLOUD_EXPORT QString errorText(ErrorCode code, const QVariant &details = QVariant());
+
+/**
  * @brief System status
  *
  * Corresponds to the @c emsStatus field on the @c /getEssList endpoint.


### PR DESCRIPTION
Given an ErrorCode (and optional details) it creates a human-readable text, so that ApiRequest::errorString is never empty when there is an error and subsequently can be displayed in the UI directly.