### PR TITLE
configuration: Move default configuration to ~/.config

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -47,6 +47,7 @@ jobs:
     - name: XDG Base Dirs
       run: |
         mkdir -p "$HOME/.qttest/cache"
+        mkdir -p "$HOME/.qttest/config"
 
     - name: Test
       env:

--- a/README.md
+++ b/README.md
@@ -96,9 +96,10 @@ This project is configured using `cmake` and is built with [Qt](https://www.qt.i
 
 ### API Keys
 
-The API access configuration should be placed in the file `~/.config/Broulik/QAlphaCloud.conf` (create directories as needed):
+The API access configuration should be placed in the configuration file `~/.config/qalphacloud.ini`:
 ```
 [Api]
+ApiUrl=https://... # optional
 AppId=alpha...
 AppSecret=...
 ```

--- a/autotests/data/qalphacloud.ini
+++ b/autotests/data/qalphacloud.ini
@@ -1,0 +1,4 @@
+[Api]
+ApiUrl=https://www.example.com/api/
+AppId=alpha123456
+AppSecret=abc123456789

--- a/autotests/data/qalphacloud.ini.license
+++ b/autotests/data/qalphacloud.ini.license
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2023 Kai Uwe Broulik <ghqalpha@broulik.de>

--- a/src/lib/configuration.cpp
+++ b/src/lib/configuration.cpp
@@ -9,6 +9,7 @@
 #include "qalphacloud_log.h"
 
 #include <QSettings>
+#include <QStandardPaths>
 
 namespace QAlphaCloud
 {
@@ -38,6 +39,11 @@ Configuration *Configuration::defaultConfiguration(QObject *parent)
     auto *configuration = new Configuration(parent);
     configuration->loadDefault();
     return configuration;
+}
+
+QString Configuration::defaultConfigurationPath()
+{
+    return QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation) + QLatin1String("/qalphacloud.ini");
 }
 
 QUrl Configuration::apiUrl() const
@@ -181,8 +187,7 @@ bool Configuration::loadFromSettings(QSettings *settings)
 
 bool Configuration::loadDefault()
 {
-    QSettings settings(QStringLiteral("Broulik"), QStringLiteral("QAlphaCloud"));
-    return loadFromSettings(&settings);
+    return loadFromFile(defaultConfigurationPath());
 }
 
 } // namespace QAlphaCloud

--- a/src/lib/configuration.h
+++ b/src/lib/configuration.h
@@ -95,6 +95,17 @@ public:
      */
     static Configuration *defaultConfiguration(QObject *parent = nullptr);
 
+    /**
+     * @brief The default configuration path.
+     *
+     * This is is "qalphacloud.ini" within the user's configuration directory.
+     *
+     * @note This does not check if this file exists.
+     *
+     * @return The path to the default configuration file.
+     */
+    static QString defaultConfigurationPath();
+
     Q_REQUIRED_RESULT QUrl apiUrl() const;
     void setApiUrl(const QUrl &apiUrl);
     /**


### PR DESCRIPTION
I find it awkward to have my name in there :-)

Also add a getter for this path and add a unit test.