### PR TITLE
storagesystemsmodel: Set status to finished after reloading same data

### DIFF
--- a/src/lib/storagesystemsmodel.cpp
+++ b/src/lib/storagesystemsmodel.cpp
@@ -176,26 +176,24 @@ void StorageSystemsModelPrivate::processApiResult(const QJsonArray &jsonArray)
         }
     }
 
-    if (!dirty) {
-        return;
-    }
+    if (dirty) {
+        const QString oldPrimarySerialNumber = q->primarySerialNumber();
 
-    const QString oldPrimarySerialNumber = q->primarySerialNumber();
+        q->beginResetModel();
 
-    q->beginResetModel();
+        m_data.clear();
 
-    m_data.clear();
+        m_data.reserve(jsonArray.count());
 
-    m_data.reserve(jsonArray.count());
+        for (const QJsonValue &systemValue : jsonArray) {
+            m_data << StorageSystem::fromJson(systemValue.toObject());
+        }
 
-    for (const QJsonValue &systemValue : jsonArray) {
-        m_data << StorageSystem::fromJson(systemValue.toObject());
-    }
+        q->endResetModel();
 
-    q->endResetModel();
-
-    if (oldPrimarySerialNumber != q->primarySerialNumber()) {
-        Q_EMIT q->primarySerialNumberChanged(q->primarySerialNumber());
+        if (oldPrimarySerialNumber != q->primarySerialNumber()) {
+            Q_EMIT q->primarySerialNumberChanged(q->primarySerialNumber());
+        }
     }
 
     setStatus(QAlphaCloud::RequestStatus::Finished);


### PR DESCRIPTION
We bailed out early when data didn't change but there we forgot to set the status back to Finished.

This broke reloading the infocenter because it just clears its cumulative/history data and then reloads them once the storagesystemsmodel has finished loading.