### PR TITLE
livedataobject: Update values in lock-step

### DIFF
--- a/src/systemstats/livedataobject.h
+++ b/src/systemstats/livedataobject.h
@@ -31,8 +31,7 @@ public:
     void update();
 
 private:
-    void updateGridPower(int power);
-    void updateBatteryPower(int power);
+    void reload();
 
     QAlphaCloud::LastPowerData *m_liveData = nullptr;
 


### PR DESCRIPTION
Update all values when ksystemstats asks us to rather than updating them when the relevant property change is emitted.

Probably doesn't change much but could make plasma-systemmonitor behave more predictable.