### PR TITLE
cmake: Add find_package call for KPackage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ if (BUILD_KSYSTEMSTATS)
 endif()
 
 if (BUILD_KINFOCENTER)
-    find_package(KF${QT_MAJOR_VERSION} ${KF_MIN_VERSION} REQUIRED COMPONENTS CoreAddons Declarative)
+    find_package(KF${QT_MAJOR_VERSION} ${KF_MIN_VERSION} REQUIRED COMPONENTS CoreAddons Declarative Package)
 
     find_package(Qt${QT_MAJOR_VERSION}QuickControls2 ${QT_MIN_VERSION})
     set_package_properties(Qt${QT_MAJOR_VERSION}QuickControls2 PROPERTIES


### PR DESCRIPTION
It's obviously where kpackage_install_package lives.

This fails in a KF6 build, must have been pulled in transitively in KF5.