### PR TITLE
systemstats: Add "Remaining time" property

### DIFF
--- a/src/systemstats/livedataobject.h
+++ b/src/systemstats/livedataobject.h
@@ -50,6 +50,8 @@ private:
 
     KSysGuard::SensorProperty *m_batteryChargeProperty = nullptr;
     KSysGuard::SensorProperty *m_batteryDischargeProperty = nullptr;
+
+    KSysGuard::SensorProperty *m_batteryTimeProperty = nullptr;
     // TODO battery status property
 
     // Mirrored from StorageSystemsModel


### PR DESCRIPTION
Reports the time until the battery is fully charged (when charging) or empty (when discharging).

It doesn't do any rounding, so the value is reported down to the second even though it's of course nowhere as accurate.