### PR TITLE
Use Qt built-in timeout handling

### DIFF
--- a/src/lib/apirequest_p.h
+++ b/src/lib/apirequest_p.h
@@ -14,8 +14,6 @@
 
 #include "qalphacloud.h"
 
-class QTimer;
-
 namespace QAlphaCloud
 {
 
@@ -91,8 +89,6 @@ private:
     QAlphaCloud::ErrorCode m_error = QAlphaCloud::ErrorCode::NoError;
     QString m_errorString;
     QJsonValue m_data;
-
-    QTimer *m_timeoutTimer = nullptr;
 };
 
 } // namespace QAlphaCloud


### PR DESCRIPTION
Instead of spinning our own QTimer (which was overall quite brittle, often when I resumed from suspend my system monitor was just broken and didn't receive any data anymore) set QNetworkRequest::transferTimeout.